### PR TITLE
force strings with tabs to be wrapped in quotes

### DIFF
--- a/sheetclip.js
+++ b/sheetclip.js
@@ -65,7 +65,7 @@
           }
           val = arr[r][c];
           if (typeof val === 'string') {
-            if (val.indexOf('\n') > -1) {
+            if (val.match(/\n|\t/)) {
               str += '"' + val.replace(/"/g, '""') + '"';
             }
             else {


### PR DESCRIPTION
SheetClip.stringify does not wrap strings that contain tabs but no newlines.

To generate such a monstrosity, set 

```
A1=1&CHAR(9)&2
```

On Excel 2011 it's displayed as if the tab is a single character, but copying and pasting (pbcopy/pbpaste) reveals that an actual tab character is there!
